### PR TITLE
Remove foreach loop with non existing local property

### DIFF
--- a/embed-google-fonts.php
+++ b/embed-google-fonts.php
@@ -155,10 +155,6 @@ class Embed_Google_Fonts {
 			}
 			echo 'src:';
 
-			foreach ( $variant->local as $local ) {
-				echo 'local("' . $local . '"),';
-			}
-
 			$formats = array();
 			foreach (
 				[


### PR DESCRIPTION
PHP logs an "Invalid argument supplied for foreach()" warning because $variant does not have a "local" property