### PR TITLE
Add korean subset

### DIFF
--- a/embed-google-fonts.php
+++ b/embed-google-fonts.php
@@ -94,6 +94,7 @@ class Embed_Google_Fonts {
 			'cyrillic',
 			'latin-ext',
 			'hebrew',
+			'korean',
 			'oriya'
 		] );
 		$configuration_url = add_query_arg( [ 'subsets' => join( ',', $subsets ) ], $api_url );


### PR DESCRIPTION
noto-sans-kr for example is cached as "noto-sans-kr-v27-latin_korean-regular.eot" in _font.css and as filename "noto-sans-kr-v27-latin_korean-regular.eot" in the cache folder. This leads to broken links.

Other solution could be parsing the filenames for css after download.